### PR TITLE
execution-status: add InvalidTxContext command argument error

### DIFF
--- a/proto/sui/rpc/v2/execution_status.proto
+++ b/proto/sui/rpc/v2/execution_status.proto
@@ -348,6 +348,11 @@ message CommandArgumentError {
     // argument is a mutable reference and it conflicts with another argument to the call, or the
     // argument is mutable and another reference extends it and will be used in a later command.
     INVALID_REFERENCE_ARGUMENT = 19;
+
+    // Invalid usage of TxContext in the function signature. TxContext can only be used by
+    // reference, `&TxContext` or `&mut TxContext`. If used mutably, it must be the only
+    // TxContext parameter, and TxContext can never be returned from a Move call.
+    INVALID_TX_CONTEXT = 20;
   }
 
   optional CommandArgumentErrorKind kind = 2;


### PR DESCRIPTION
Add the `INVALID_TX_CONTEXT` command argument error kind, emitted by the adapter's new PTB TxContext signature restrictions (MystenLabs/sui#27451).

cc @bmwill