### PR TITLE
move_package: add version and at_checkpoint to GetPackageRequest

### DIFF
--- a/proto/sui/rpc/v2/move_package_service.proto
+++ b/proto/sui/rpc/v2/move_package_service.proto
@@ -15,8 +15,27 @@ service MovePackageService {
 }
 
 message GetPackageRequest {
-  // Required. The `storage_id` of the requested package.
+  // Required. The `storage_id` of any version of the requested package.
+  //
+  // When `version` is not set, the package stored at exactly this id is
+  // returned. When `version` is set, `package_id` only identifies the
+  // package's upgrade lineage (via its original id), and the requested
+  // version within that lineage is returned.
   optional string package_id = 1;
+
+  // Optional. Return the package in `package_id`'s upgrade lineage that
+  // matches one of the following:
+  //
+  // - `version`: the package with exactly this version.
+  // - `at_checkpoint`: the latest package that existed at or before this
+  //   checkpoint. Values above the current ledger tip resolve to the latest
+  //   known version.
+  //
+  // If neither is set, the package stored at `package_id` is returned.
+  oneof selector {
+    uint64 version = 2;
+    uint64 at_checkpoint = 3;
+  }
 }
 
 message GetPackageResponse {


### PR DESCRIPTION
Extend `MovePackageService.GetPackage`

Calling with package_id still fetches the exact package.

Additionally, only one of the two can be provided:
- version: return the lineage's package at exactly this version.
- at_checkpoint: return the latest lineage package that existed at or before this checkpoint; values above the ledger tip resolve to the latest known version.

MystenLabs/sui-rust-sdk#305